### PR TITLE
Add i18n with english and french

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "ajv": "^8.17.1",
     "ajv-keywords": "^5.1.0",
     "decimal.js": "^10.4.3",
+    "i18next": "^22.4.9",
+    "react-i18next": "^13.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "^5.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import './App.css';
 import {Container, CssBaseline} from "@mui/material";
 import ConvertorPage from './pages/ConvertorPage';
+import Header from './components/Header';
 
 function App() {
   return (
       <div>
         <CssBaseline />
+        <Header />
         <Container >
           <ConvertorPage />
         </Container>

--- a/src/components/Convertor.tsx
+++ b/src/components/Convertor.tsx
@@ -5,6 +5,7 @@ import {
     IconButton,
     TextField
 } from "@mui/material";
+import { useTranslation } from 'react-i18next';
 
 import {SwapHoriz} from "@mui/icons-material";
 import {GLOBAL_CONF} from "../config/globalConf";
@@ -25,6 +26,7 @@ export interface ConversionResult {
 }
 
 const Convertor = ({rate, onConversion }: ConvertorProps) => {
+    const { t } = useTranslation();
     const [amount, setAmount] = useState<number>(0);
     const [fromCurrency, setFromCurrency] = useState<Currency>(GLOBAL_CONF.CURRENCIES.EUR as Currency);
     const [toCurrency, setToCurrency] = useState< Currency>(GLOBAL_CONF.CURRENCIES.USD as Currency);
@@ -65,23 +67,23 @@ const Convertor = ({rate, onConversion }: ConvertorProps) => {
         <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', mb: 2 }}>
             <FormControl variant="outlined" sx={{ m: 1, minWidth: 120 }}>
                 <TextField
-                    label="Amount"
+                    label={t('amount')}
                     value={amount}
                     type={"number"}
                     onChange={handleInputChange}
                     variant="outlined"
-                    placeholder="Enter the amount"
+                    placeholder={t('enterAmount')}
                 />
             </FormControl>
 
-            <CurrencySelector currency={fromCurrency} label={'From'} />
+            <CurrencySelector currency={fromCurrency} label={t('from')} />
             <IconButton color="primary" sx={{ m: 1 }} onClick={handleSwapCurrencies}>
                 <SwapHoriz />
             </IconButton>
 
             <FormControl variant="outlined" sx={{ m: 1, minWidth: 120 }}>
                 <TextField
-                    label="Result"
+                    label={t('result')}
                     value={resultAmount.toFixed(2)}
                     type={"number"}
                     disabled
@@ -90,7 +92,7 @@ const Convertor = ({rate, onConversion }: ConvertorProps) => {
                 />
             </FormControl>
 
-            <CurrencySelector currency={toCurrency} label={'To'} />
+            <CurrencySelector currency={toCurrency} label={t('to')} />
 
         </Box>
     );

--- a/src/components/ExchangeRateDisplay.tsx
+++ b/src/components/ExchangeRateDisplay.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import {Box, TextField, Typography} from "@mui/material";
+import { useTranslation } from 'react-i18next';
 import {GLOBAL_CONF} from "../config/globalConf";
 import {isDeviationMoreThanLimit} from "../services/calculator";
 
 
 const ExchangeRateDisplay = ({rate, onRateChange, onRealRateUpdate}: {rate: number, onRealRateUpdate: (value: number) => void, onRateChange: (value: number) => void}) => {
+    const { t } = useTranslation();
     const [currentRate, setCurrentRate] = useState<number>(rate);
     const [fixedRate, setFixedRate] = useState<number | null>(null);
     const [fixedRateError, setFixedRateError] = useState<string>('');
@@ -13,7 +15,7 @@ const ExchangeRateDisplay = ({rate, onRateChange, onRealRateUpdate}: {rate: numb
     const isFixedRateAllowed = (): boolean => {
         if(fixedRate) {
             const isAllowed = !isDeviationMoreThanLimit(fixedRate, currentRate, GLOBAL_CONF.RESET_FIXED_RATE_LIMIT)
-            setFixedRateError(!isAllowed ? `Fixed rate disabled: ${GLOBAL_CONF.RESET_FIXED_RATE_LIMIT}% deviation exceeded` : '')
+            setFixedRateError(!isAllowed ? t('fixedRateDisabled', {limit: GLOBAL_CONF.RESET_FIXED_RATE_LIMIT}) : '')
             return isAllowed;
         }
         return false
@@ -58,10 +60,10 @@ const ExchangeRateDisplay = ({rate, onRateChange, onRealRateUpdate}: {rate: numb
         <>
             <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', mb: 2 }}>
                 <Typography variant="h6" component="h2" style={{ marginTop: '20px', width: '50%' }}>
-                    Current rate: <span data-testid="exchange-rate">{currentRate.toFixed(2)}</span>
+                    {t('currentRate')} <span data-testid="exchange-rate">{currentRate.toFixed(2)}</span>
                 </Typography>
                 <TextField
-                    label="Set Fixed Exchange Rate"
+                    label={t('setFixedRate')}
                     variant="outlined"
                     value={fixedRate ?? ''}
                     onChange={handleFixedRateChange}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import {AppBar, Toolbar, Typography, Select, MenuItem} from '@mui/material';
+import type {SelectChangeEvent} from '@mui/material/Select';
 import {useTranslation} from 'react-i18next';
 
 const Header = () => {
   const { t, i18n } = useTranslation();
 
-  const handleLanguageChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+  const handleLanguageChange = (event: SelectChangeEvent<string>) => {
     i18n.changeLanguage(event.target.value as string);
   };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {AppBar, Toolbar, Typography, Select, MenuItem} from '@mui/material';
+import {useTranslation} from 'react-i18next';
+
+const Header = () => {
+  const { t, i18n } = useTranslation();
+
+  const handleLanguageChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    i18n.changeLanguage(event.target.value as string);
+  };
+
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          {t('appName')}
+        </Typography>
+        <Typography sx={{mr:1}}>{t('language')}</Typography>
+        <Select
+          value={i18n.language}
+          onChange={handleLanguageChange}
+          variant="standard"
+          sx={{ color: 'white', borderBottom: '1px solid white' }}
+        >
+          <MenuItem value="en">English</MenuItem>
+          <MenuItem value="fr">Français</MenuItem>
+        </Select>
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+export default Header;

--- a/src/components/HistoryTable.tsx
+++ b/src/components/HistoryTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Table, TableHead, TableBody, TableRow, TableCell } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 
 interface ConversionRecord {
     from: string;
@@ -15,16 +16,17 @@ interface HistoryTableProps {
 }
 
 const HistoryTable = ({ history }: HistoryTableProps) => {
+    const { t } = useTranslation();
     return (
         <Table>
             <TableHead>
                 <TableRow>
-                    <TableCell>From</TableCell>
-                    <TableCell>To</TableCell>
-                    <TableCell>Current Rate</TableCell>
-                    <TableCell>Real Rate</TableCell>
-                    <TableCell>Amount</TableCell>
-                    <TableCell>Result</TableCell>
+                    <TableCell>{t('from')}</TableCell>
+                    <TableCell>{t('to')}</TableCell>
+                    <TableCell>{t('currentRateHeader')}</TableCell>
+                    <TableCell>{t('realRate')}</TableCell>
+                    <TableCell>{t('amountHeader')}</TableCell>
+                    <TableCell>{t('resultHeader')}</TableCell>
                 </TableRow>
             </TableHead>
             <TableBody>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,20 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en.json';
+import fr from './locales/fr.json';
+
+void i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      fr: { translation: fr },
+    },
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+export default i18n;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import './i18n';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "appName": "Euro Dollar Converter",
+  "language": "Language",
+  "amount": "Amount",
+  "enterAmount": "Enter the amount",
+  "result": "Result",
+  "from": "From",
+  "to": "To",
+  "currentRate": "Current rate:",
+  "setFixedRate": "Set Fixed Exchange Rate",
+  "fixedRateDisabled": "Fixed rate disabled: {{limit}}% deviation exceeded",
+  "currentRateHeader": "Current Rate",
+  "realRate": "Real Rate",
+  "amountHeader": "Amount",
+  "resultHeader": "Result",
+  "pageTitle": "Euro to Dollar Converter"
+}

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,17 @@
+{
+  "appName": "Convertisseur Euro Dollar",
+  "language": "Langue",
+  "amount": "Montant",
+  "enterAmount": "Entrez le montant",
+  "result": "Résultat",
+  "from": "De",
+  "to": "À",
+  "currentRate": "Taux actuel :",
+  "setFixedRate": "Définir le taux fixe",
+  "fixedRateDisabled": "Taux fixe désactivé : dépassement de {{limit}}%",
+  "currentRateHeader": "Taux Courant",
+  "realRate": "Taux Réel",
+  "amountHeader": "Montant",
+  "resultHeader": "Résultat",
+  "pageTitle": "Convertisseur Euro vers Dollar"
+}

--- a/src/pages/ConvertorPage.tsx
+++ b/src/pages/ConvertorPage.tsx
@@ -3,6 +3,7 @@ import {
     Container,
     Typography
 } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import ExchangeRateDisplay from "../components/ExchangeRateDisplay";
 import HistoryTable from "../components/HistoryTable";
 import {GLOBAL_CONF} from "../config/globalConf";
@@ -10,6 +11,7 @@ import Convertor, {ConversionResult} from "../components/Convertor";
 
 
 const ConvertorPage = () => {
+    const { t } = useTranslation();
     const [rate, setRate] = useState<number>(GLOBAL_CONF.INITIAL_RATE);
     const [realRate, setRealRate] = useState<number>(GLOBAL_CONF.INITIAL_RATE);
     const [history, setHistory] = useState<any[]>([]);
@@ -35,7 +37,7 @@ const ConvertorPage = () => {
 
     return (
         <Container maxWidth={'lg'} style={{ marginTop: '50px' }}>
-            <Typography variant="h4">Euro to Dollar Converter</Typography>
+            <Typography variant="h4">{t('pageTitle')}</Typography>
             <ExchangeRateDisplay rate={rate} onRateChange={setRate} onRealRateUpdate={setRealRate}  />
             <Convertor rate={rate} onConversion={hadleConversionDone} />
             <HistoryTable history={history} />


### PR DESCRIPTION
## Summary
- add `i18next` and `react-i18next` dependencies
- set up i18n with English and French translations
- create header with language switch
- translate all UI text

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68418d381a8c8321beaf135b08157f42