### PR TITLE
Add DTN currency to converter

### DIFF
--- a/src/components/Convertor.tsx
+++ b/src/components/Convertor.tsx
@@ -10,10 +10,11 @@ import {SwapHoriz} from "@mui/icons-material";
 import {GLOBAL_CONF} from "../config/globalConf";
 import CurrencySelector from "./CurrencySelector";
 import {calculateAmount} from "../services/calculator";
-type Currency = 'EUR' | 'USD';
+type Currency = 'EUR' | 'USD' | 'DTN';
 
 interface ConvertorProps {
-    rate: number;
+    rates: { USD: number; DTN: number };
+    realUsdRate: number;
     onConversion: (value: ConversionResult) => void;
 }
 
@@ -22,9 +23,11 @@ export interface ConversionResult {
     value: number;
     fromCurrency: Currency;
     toCurrency: Currency;
+    rate: number;
+    realRate: number;
 }
 
-const Convertor = ({rate, onConversion }: ConvertorProps) => {
+const Convertor = ({rates, realUsdRate, onConversion }: ConvertorProps) => {
     const [amount, setAmount] = useState<number>(0);
     const [fromCurrency, setFromCurrency] = useState<Currency>(GLOBAL_CONF.CURRENCIES.EUR as Currency);
     const [toCurrency, setToCurrency] = useState< Currency>(GLOBAL_CONF.CURRENCIES.USD as Currency);
@@ -44,18 +47,43 @@ const Convertor = ({rate, onConversion }: ConvertorProps) => {
     useEffect(() => {
         updateResult(amount);
 
-    }, [rate, amount])
+    }, [rates, amount, fromCurrency, toCurrency])
+
+    const getRate = (from: Currency, to: Currency, useReal = false): number => {
+        const usdRate = useReal ? realUsdRate : rates.USD;
+        const dtnRate = rates.DTN;
+
+        if (from === to) return 1;
+        switch (from) {
+            case GLOBAL_CONF.CURRENCIES.EUR:
+                if (to === GLOBAL_CONF.CURRENCIES.USD) return usdRate;
+                if (to === GLOBAL_CONF.CURRENCIES.DTN) return dtnRate;
+                break;
+            case GLOBAL_CONF.CURRENCIES.USD:
+                if (to === GLOBAL_CONF.CURRENCIES.EUR) return 1 / usdRate;
+                if (to === GLOBAL_CONF.CURRENCIES.DTN) return (1 / usdRate) * dtnRate;
+                break;
+            case GLOBAL_CONF.CURRENCIES.DTN:
+                if (to === GLOBAL_CONF.CURRENCIES.EUR) return 1 / dtnRate;
+                if (to === GLOBAL_CONF.CURRENCIES.USD) return (1 / dtnRate) * usdRate;
+                break;
+        }
+        return 1;
+    };
 
     const updateResult = (value: number) => {
-        let operation: 'MULT' | 'DIV' = fromCurrency === GLOBAL_CONF.CURRENCIES.EUR ?  'MULT': 'DIV';
-        const result = calculateAmount(value, rate, operation);
+        const rate = getRate(fromCurrency, toCurrency);
+        const realRate = getRate(fromCurrency, toCurrency, true);
+        const result = calculateAmount(value, rate, 'MULT');
         setResultAmount(result);
         if(amount !== 0) {
             onConversion({
                 amount: amount,
                 value: result,
                 fromCurrency: fromCurrency,
-                toCurrency: toCurrency
+                toCurrency: toCurrency,
+                rate: rate,
+                realRate: realRate
             });
         }
 
@@ -74,7 +102,7 @@ const Convertor = ({rate, onConversion }: ConvertorProps) => {
                 />
             </FormControl>
 
-            <CurrencySelector currency={fromCurrency} label={'From'} />
+            <CurrencySelector currency={fromCurrency} label={'From'} onChange={setFromCurrency} />
             <IconButton color="primary" sx={{ m: 1 }} onClick={handleSwapCurrencies}>
                 <SwapHoriz />
             </IconButton>
@@ -90,7 +118,7 @@ const Convertor = ({rate, onConversion }: ConvertorProps) => {
                 />
             </FormControl>
 
-            <CurrencySelector currency={toCurrency} label={'To'} />
+            <CurrencySelector currency={toCurrency} label={'To'} onChange={setToCurrency} />
 
         </Box>
     );

--- a/src/components/CurrencySelector.tsx
+++ b/src/components/CurrencySelector.tsx
@@ -9,21 +9,26 @@ import {
 import {GLOBAL_CONF} from "../config/globalConf";
 import EuroIcon from "@mui/icons-material/Euro";
 import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
+import CurrencyExchangeIcon from "@mui/icons-material/CurrencyExchange";
+
+type Currency = 'EUR' | 'USD' | 'DTN';
 
 interface CurrencySelectorProps {
-    currency: 'EUR' | 'USD';
+    currency: Currency;
     label: string;
+    onChange: (currency: Currency) => void;
 }
 
-const CurrencySelector = ({ currency, label }: CurrencySelectorProps) => {
+const CurrencySelector = ({ currency, label, onChange }: CurrencySelectorProps) => {
 
 
     return (
         <FormControl variant="outlined" sx={{ m: 1 }}>
             <InputLabel>{label}</InputLabel>
-            <Select value={currency} onChange={(e) => {}} label={label} disabled>
+            <Select value={currency} onChange={(e) => onChange(e.target.value as Currency)} label={label}>
                 <MenuItem value={GLOBAL_CONF.CURRENCIES.EUR}><ListItemIcon><EuroIcon/></ListItemIcon>EUR</MenuItem>
                 <MenuItem value={GLOBAL_CONF.CURRENCIES.USD}><ListItemIcon><AttachMoneyIcon/></ListItemIcon>USD</MenuItem>
+                <MenuItem value={GLOBAL_CONF.CURRENCIES.DTN}><ListItemIcon><CurrencyExchangeIcon/></ListItemIcon>DTN</MenuItem>
             </Select>
         </FormControl>
     );

--- a/src/config/globalConf.ts
+++ b/src/config/globalConf.ts
@@ -1,9 +1,11 @@
 export const GLOBAL_CONF = {
     INITIAL_RATE: 1.1,
+    INITIAL_DTN_RATE: 3.3,
     UPDATE_RATE_INTERVAL: 3000,
     RESET_FIXED_RATE_LIMIT: 2,
     CURRENCIES: {
         EUR: 'EUR',
-        USD: 'USD'
+        USD: 'USD',
+        DTN: 'DTN'
     }
 }

--- a/src/pages/ConvertorPage.tsx
+++ b/src/pages/ConvertorPage.tsx
@@ -12,6 +12,7 @@ import Convertor, {ConversionResult} from "../components/Convertor";
 const ConvertorPage = () => {
     const [rate, setRate] = useState<number>(GLOBAL_CONF.INITIAL_RATE);
     const [realRate, setRealRate] = useState<number>(GLOBAL_CONF.INITIAL_RATE);
+    const dtnRate = GLOBAL_CONF.INITIAL_DTN_RATE;
     const [history, setHistory] = useState<any[]>([]);
 
 
@@ -20,8 +21,8 @@ const ConvertorPage = () => {
             {
                 from: conversion.fromCurrency,
                 to: conversion.toCurrency,
-                rate: rate.toFixed(2),
-                realRate: realRate.toFixed(2),
+                rate: conversion.rate.toFixed(2),
+                realRate: conversion.realRate.toFixed(2),
                 amount: conversion.amount.toFixed(2),
                 result: conversion.value.toFixed(2)
             },
@@ -37,7 +38,7 @@ const ConvertorPage = () => {
         <Container maxWidth={'lg'} style={{ marginTop: '50px' }}>
             <Typography variant="h4">Euro to Dollar Converter</Typography>
             <ExchangeRateDisplay rate={rate} onRateChange={setRate} onRealRateUpdate={setRealRate}  />
-            <Convertor rate={rate} onConversion={hadleConversionDone} />
+            <Convertor rates={{USD: rate, DTN: dtnRate}} realUsdRate={realRate} onConversion={hadleConversionDone} />
             <HistoryTable history={history} />
         </Container>
     );


### PR DESCRIPTION
## Summary
- include DTN in supported currencies
- allow selecting currency in dropdown
- compute conversion across EUR, USD and DTN

## Testing
- `CI=true npm test --silent`
- `npm run test:cucumber --silent` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68498fa96a40832185021e4db8f1dc0b